### PR TITLE
feat: add NotFair — Claude Code skills for SEO, Google Ads, and Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A collection of reusable skill prompts for Claude, designed to produce consisten
 | [grill-me](./skills/grill-me/) | Relentless design interview | Stress-testing plans |
 | [grill-with-docs](./skills/grill-with-docs/) | Plan vs domain/docs alignment | Terminological precision |
 | [to-issues](./skills/to-issues/) | Vertical slicing into tickets | Task breakdown |
+| [notfair](https://github.com/nowork-studio/NotFair) | Claude Code skills for SEO, GEO, Google Ads, and Meta Ads — connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP | Marketing audits, keyword research, paid-ads optimization |
 | [write-a-skill](./skills/write-a-skill/) | Creating new agent skills | Extending capabilities |
 
 ## Creating a New Skill


### PR DESCRIPTION
Hi, thanks for putting together this collection of Claude skills!

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair) (~2.9k stars), an open-source set of Claude Code skills focused on marketing work — specifically SEO/GEO analysis, Google Ads management, and Meta (Facebook + Instagram) Ads. It connects to live account data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so skills can pull real metrics rather than working from static snapshots.

The sub-skills cover things like site audits, keyword research, meta tag optimization, schema markup, wasted-spend detection, search-term cleanup, creative fatigue analysis, and audience overlap checks — each following the same atomic, single-purpose pattern your existing skills use.

I added it to the skills table in the README. Happy to adjust the description, move it to a different section, or trim anything that doesn't fit the style. Thanks for considering it!