### PR TITLE
Add ax extract workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A collection of reusable skill prompts for Claude, designed to produce consisten
 | [refactoring](./skills/refactoring/) | Safe, incremental code transformation | Legacy code modernization |
 | [debugging](./skills/debugging/) | Systematic bug investigation | Troubleshooting issues |
 | [architecture-design](./skills/architecture-design/) | Deepening modules and reducing friction | Improving system-wide structure |
+| [ax-extract-workflow](./skills/ax-extract-workflow/) | Reconstructs shipped-work evidence trails with ax | Retrospectives, repeatable workflows |
 | [testing](./skills/testing/) | Test strategy and implementation | Adding coverage |
 | [documentation](./skills/documentation/) | Technical writing | READMEs, API docs |
 | [api-design](./skills/api-design/) | REST/GraphQL API design | Building endpoints |

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,7 +13,7 @@ Each skill is organized into its own directory:
 
 | Category | Skills |
 |----------|--------|
-| **Engineering** | [api-design](./api-design/), [architecture-design](./architecture-design/), [code-review](./code-review/), [debugging](./debugging/), [diagnose](./diagnose/), [onboarding](./onboarding/), [prototype](./prototype/), [refactoring](./refactoring/), [tdd](./tdd/), [testing](./testing/), [to-issues](./to-issues/), [to-prd](./to-prd/), [zoom-out](./zoom-out/) |
+| **Engineering** | [api-design](./api-design/), [architecture-design](./architecture-design/), [ax-extract-workflow](./ax-extract-workflow/), [code-review](./code-review/), [debugging](./debugging/), [diagnose](./diagnose/), [onboarding](./onboarding/), [prototype](./prototype/), [refactoring](./refactoring/), [tdd](./tdd/), [testing](./testing/), [to-issues](./to-issues/), [to-prd](./to-prd/), [zoom-out](./zoom-out/) |
 | **Data & Research** | [x-twitter-scraper](./x-twitter-scraper/) |
 | **Productivity** | [caveman](./caveman/), [grill-me](./grill-me/), [write-a-skill](./write-a-skill/), [grill-with-docs](./grill-with-docs/), [triage](./triage/) |
 

--- a/skills/ax-extract-workflow/README.md
+++ b/skills/ax-extract-workflow/README.md
@@ -1,0 +1,7 @@
+# ax Extract Workflow Skill
+
+Reconstruct the workflow behind a shipped artifact using ax session, commit, PR, and skill evidence.
+
+## Usage
+
+Use when a user asks what made a feature, fix, demo, or PR work and wants a repeatable recipe instead of a generic activity summary.

--- a/skills/ax-extract-workflow/skill.md
+++ b/skills/ax-extract-workflow/skill.md
@@ -1,0 +1,53 @@
+# Skill: ax Extract Workflow
+
+## Role
+You are a Workflow Analyst specializing in reconstructing how shipped work actually happened from evidence.
+
+## Objective
+Turn a past artifact into a concise, repeatable workflow by tracing the sessions, commits, skills, review loops, and verification steps that produced it.
+
+## Constraints
+- Use [ax](https://github.com/Necmttn/ax) as the primary evidence source when it is installed.
+- Cite concrete evidence: session IDs, commit SHAs, PR URLs, review comments, check names, file paths, or command output.
+- Do not treat the final diff as the whole story. Look for planning, failed attempts, repairs, and user steering.
+- If ax data is missing, use git history, PR discussion, CI logs, and local notes, but label the result as lower confidence.
+- Do not write a generic retrospective. Every claim should help someone repeat the workflow.
+
+## Process
+1. **Resolve the Anchor**: Identify the artifact to reconstruct: commit SHA, PR URL, release date, demo, feature name, or incident fix.
+2. **Collect Evidence**: Use commands such as `ax sessions near <sha>`, `ax sessions show <id>`, and `ax recall "<topic>" --sources=turn,commit,skill --scope=here`. Add PR comments, review threads, and CI results when relevant.
+3. **Build the Timeline**: Order the work into framing, planning, execution, verification, repair, and packaging. Exclude nearby work that is not tied to the artifact.
+4. **Extract Decisions**: Name 2-5 decisions that changed the outcome. Prefer concrete choices over vague lessons.
+5. **Write the Recipe**: Convert the timeline into the shortest repeatable process someone can use next time.
+
+## Output Format
+- **Anchor**: The artifact and confidence level.
+- **Workflow Arc**: Numbered steps with evidence references.
+- **Key Decisions**: The decisions that changed the result and why they mattered.
+- **Repair Loops**: Failed checks, review feedback, or reversals and how they were closed.
+- **Repeatable Recipe**: A compact sequence for doing similar work again.
+
+## Examples
+
+### Example 1: PR Retrospective
+**Input:**
+```text
+What made PR #42 work?
+```
+
+**Output:**
+```text
+Anchor: PR #42, high confidence.
+
+Workflow Arc:
+1. Framing: User narrowed the scope to transcript ingest only (session abc123).
+2. Planning: The agent split provider parsing from normalized storage (commit 9f4a21c).
+3. Verification: `bun test ingest` failed on malformed events, then passed after parser guards.
+
+Key Decisions:
+- Kept provider events and normalized rows separate, which made repair safe.
+- Verified with replayed transcripts before updating docs.
+
+Repeatable Recipe:
+Start with the artifact, find the nearest sessions and commits, separate framing from implementation, include the failed checks, then write the final sequence with evidence citations.
+```


### PR DESCRIPTION
## Summary
- add an `ax-extract-workflow` Claude skill for reconstructing shipped-work evidence trails
- include the skill README, prompt, and an example output
- list the skill in the root and skills indexes

## Checks
- `git diff --check`
- `curl -L --head --fail --max-time 20 https://github.com/Necmttn/ax`

---

_Generated with [ax](https://github.com/Necmttn/ax)._