### PR TITLE
Add Linked API linkedin skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 | [grill-with-docs](./skills/grill-with-docs/) | Plan vs domain/docs alignment | Terminological precision |
 | [to-issues](./skills/to-issues/) | Vertical slicing into tickets | Task breakdown |
 | [notfair](https://github.com/nowork-studio/NotFair) | Claude Code skills for SEO, GEO, Google Ads, and Meta Ads — connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP | Marketing audits, keyword research, paid-ads optimization |
+| [linkedin-skills](https://github.com/Linked-API/linkedin-skills) | LinkedIn automation skills for profile/company research, messaging, engagement, and managed network growth workflows | LinkedIn research, outreach, growth |
 | [write-a-skill](./skills/write-a-skill/) | Creating new agent skills | Extending capabilities |
 | [code-generation](./skills/code-generation/) | Rapid boilerplate and algorithm generation | Prototyping, starting new projects |
 | [prompt-engineering](./skills/prompt-engineering/) | Self-improving prompts and meta-prompting | Complex reasoning tasks |


### PR DESCRIPTION
Adds Linked API skill listing for `linkedin`.

- Skill: General LinkedIn automation
- Listing name: linkedin-skills
- Source: https://github.com/Linked-API/linkedin-skills/tree/main/linkedin
- Docs: https://linkedapi.io/skills/linkedin-skill
- Install runbook: https://linkedapi.io/skills/linkedin/install.md
- Description: Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
- Tags: LinkedIn, automation, social, agent-skill
- Catalog state: /Users/kiril/Documents/Work/LinkedAPI/.claude/skills/publish-skills/catalogs/ishandutta2007-awesome-claude-skills.md

Publication copy:
LinkedIn Skill gives AI agents natural-language access to LinkedIn automation through Linked API. It supports profile and company research, people and company search, messaging, connection requests and management, post creation, reactions, comments, stats, Sales Navigator actions, and custom workflows. It works with Claude Code, Codex, Cursor, and Windsurf and uses dedicated cloud browsers through Linked API.

Assets:
- Logo: assets/logo.png (https://linkedapi.io/logo.png)
- Social card: assets/social-card.png (https://linkedapi.io/opengraph-image?b7d7037e63c6122a)
- Screenshot: assets/screenshots/linkedin-skill.png (https://linkedapi.io/skills/linkedin-skill)